### PR TITLE
[Feat] 포춘쿠키 구현

### DIFF
--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/controller/FortuneController.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/controller/FortuneController.java
@@ -1,0 +1,63 @@
+package org.goormthon.seasonthon.nocheongmaru.domain.fortune.controller;
+
+import java.util.List;
+
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.controller.docs.FortuneControllerDocs;
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.controller.dto.FortuneRequest;
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.entity.Fortune;
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.service.FortuneService;
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.service.dto.FortuneResponse;
+import org.goormthon.seasonthon.nocheongmaru.domain.member.entity.Member;
+import org.goormthon.seasonthon.nocheongmaru.domain.member.service.MemberService;
+import org.goormthon.seasonthon.nocheongmaru.global.annotation.AuthMemberId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/fortunes")
+public class FortuneController implements FortuneControllerDocs {
+
+	private final FortuneService fortuneService;
+	private final MemberService memberService;
+
+	@PostMapping("/send")
+	public ResponseEntity<FortuneResponse> sendFortune(
+		@AuthMemberId Long memberId,
+		@RequestBody FortuneRequest request
+	) {
+		Member sender = memberService.getById(memberId);
+		Fortune fortune = fortuneService.sendFortune(sender, request.description());
+		return ResponseEntity.ok(FortuneResponse.from(fortune));
+	}
+
+	@PostMapping("/open")
+	public ResponseEntity<FortuneResponse> openFortune(
+		@AuthMemberId Long memberId
+	) {
+		Member receiver = memberService.getById(memberId);
+		Fortune fortune = fortuneService.openFortune(receiver);
+		return ResponseEntity.ok(FortuneResponse.from(fortune));
+	}
+
+	@GetMapping("/{fortuneId}")
+	public ResponseEntity<FortuneResponse> getFortune(@PathVariable Long fortuneId) {
+		return ResponseEntity.ok(fortuneService.getFortune(fortuneId));
+	}
+
+	@GetMapping("/cursor")
+	public ResponseEntity<List<FortuneResponse>> getFortunes(
+		@RequestParam(required = false) Long cursorId,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		return ResponseEntity.ok(fortuneService.getFortunes(cursorId, size));
+	}
+}

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/controller/docs/FortuneControllerDocs.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/controller/docs/FortuneControllerDocs.java
@@ -1,0 +1,56 @@
+package org.goormthon.seasonthon.nocheongmaru.domain.fortune.controller.docs;
+
+import java.util.List;
+
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.controller.dto.FortuneRequest;
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.service.dto.FortuneResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Fortune", description = "포춘쿠키 API")
+public interface FortuneControllerDocs {
+
+	@Operation(
+		summary = "포춘쿠키 작성",
+		description = "로그인한 사용자가 오늘의 포춘쿠키를 작성합니다. 하루에 한 번만 작성할 수 있습니다."
+	)
+	@ApiResponse(responseCode = "200", description = "작성 성공")
+	@ApiResponse(responseCode = "400", description = "오늘 이미 작성한 경우")
+	ResponseEntity<FortuneResponse> sendFortune(
+		Long memberId,
+		@RequestBody FortuneRequest request
+	);
+
+	@Operation(
+		summary = "포춘쿠키 열기",
+		description = "로그인한 사용자가 오늘의 포춘쿠키를 랜덤으로 열람합니다. 하루에 한 번만 열 수 있습니다."
+	)
+	@ApiResponse(responseCode = "200", description = "열람 성공")
+	@ApiResponse(responseCode = "400", description = "오늘 이미 열람한 경우 / 열 수 있는 포춘쿠키가 없는 경우")
+	ResponseEntity<FortuneResponse> openFortune(Long memberId);
+
+	@Operation(
+		summary = "포춘쿠키 단일 조회",
+		description = "fortuneId로 특정 포춘쿠키를 조회합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	@ApiResponse(responseCode = "404", description = "존재하지 않는 포춘쿠키")
+	ResponseEntity<FortuneResponse> getFortune(@PathVariable Long fortuneId);
+
+	@Operation(
+		summary = "포춘쿠키 리스트 조회 (커서 기반 페이지네이션)",
+		description = "cursorId를 기준으로 최신순 포춘쿠키를 조회합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	ResponseEntity<List<FortuneResponse>> getFortunes(
+		@Parameter(description = "마지막으로 조회한 Fortune ID (없으면 최신부터)") @RequestParam(required = false) Long cursorId,
+		@Parameter(description = "조회할 개수") @RequestParam(defaultValue = "10") int size
+	);
+}

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/controller/dto/FortuneRequest.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/controller/dto/FortuneRequest.java
@@ -1,0 +1,8 @@
+package org.goormthon.seasonthon.nocheongmaru.domain.fortune.controller.dto;
+
+import org.goormthon.seasonthon.nocheongmaru.domain.member.entity.Member;
+
+public record FortuneRequest(
+	String description,
+	Member sender
+) {}

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/entity/Fortune.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/entity/Fortune.java
@@ -10,7 +10,12 @@ import org.goormthon.seasonthon.nocheongmaru.global.common.BaseTimeEntity;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Table(name = "fortunes")
+@Table(
+    name = "fortunes",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"sender_id", "created_date"})
+    }
+)
 @Entity
 public class Fortune extends BaseTimeEntity {
     

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/repository/FortuneJpaRepository.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/repository/FortuneJpaRepository.java
@@ -1,7 +1,24 @@
 package org.goormthon.seasonthon.nocheongmaru.domain.fortune.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.goormthon.seasonthon.nocheongmaru.domain.fortune.entity.Fortune;
+import org.goormthon.seasonthon.nocheongmaru.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FortuneJpaRepository extends JpaRepository<Fortune, Long> {
+
+	boolean existsBySenderAndCreatedDate(Member sender, LocalDate createdDate);
+
+	@Query("SELECT f FROM Fortune f WHERE f.sender <> :sender AND DATE(f.createdAt) = :today ORDER BY function('RAND')")
+	List<Fortune> findRandomByTodayExcludingSender(@Param("sender") Member sender, @Param("today") LocalDate today);
+
+	@Query("SELECT f FROM Fortune f ORDER BY f.id DESC LIMIT :size")
+	List<Fortune> findTopN(@Param("size") int size);
+
+	@Query("SELECT f FROM Fortune f WHERE f.id < :cursorId ORDER BY f.id DESC LIMIT :size")
+	List<Fortune> findNextPage(@Param("cursorId") Long cursorId, @Param("size") int size);
 }

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/repository/FortuneRepository.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/repository/FortuneRepository.java
@@ -1,12 +1,41 @@
 package org.goormthon.seasonthon.nocheongmaru.domain.fortune.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
+
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.entity.Fortune;
+import org.goormthon.seasonthon.nocheongmaru.domain.member.entity.Member;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
 public class FortuneRepository {
-    
+
     private final FortuneJpaRepository fortuneJpaRepository;
-    
+
+    public boolean existsBySenderAndCreatedDate(Member sender, LocalDate createdDate) {
+        return fortuneJpaRepository.existsBySenderAndCreatedDate(sender, createdDate);
+    }
+
+    public List<Fortune> findRandomByTodayExcludingSender(Member sender, LocalDate today) {
+        return fortuneJpaRepository.findRandomByTodayExcludingSender(sender, today);
+    }
+
+    public Fortune save(Fortune fortune) {
+        return fortuneJpaRepository.save(fortune);
+    }
+
+    public Optional<Fortune> findById(Long id) {
+        return fortuneJpaRepository.findById(id);
+    }
+
+    public List<Fortune> findByCursor(Long cursorId, int size) {
+        if (cursorId == null) {
+            return fortuneJpaRepository.findTopN(size);
+        }
+        return fortuneJpaRepository.findNextPage(cursorId, size);
+    }
 }

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/service/FortuneService.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/service/FortuneService.java
@@ -1,0 +1,66 @@
+package org.goormthon.seasonthon.nocheongmaru.domain.fortune.service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.entity.Fortune;
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.repository.FortuneRepository;
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.service.dto.FortuneResponse;
+import org.goormthon.seasonthon.nocheongmaru.domain.member.entity.Member;
+import org.goormthon.seasonthon.nocheongmaru.global.exception.member.AlreadyOpenException;
+import org.goormthon.seasonthon.nocheongmaru.global.exception.member.AlreadyWrittenException;
+import org.goormthon.seasonthon.nocheongmaru.global.exception.member.FortuneNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FortuneService {
+
+	private final FortuneRepository fortuneRepo;
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+	@Transactional
+	public Fortune sendFortune(Member sender, String description) {
+		LocalDate today = LocalDate.now(KST);
+
+		if (fortuneRepo.existsBySenderAndCreatedDate(sender, today)) {
+			throw new AlreadyWrittenException();
+		}
+
+		Fortune fortune = Fortune.builder()
+			.description(description)
+			.sender(sender)
+			.build();
+
+		return fortuneRepo.save(fortune);
+	}
+
+	@Transactional
+	public Fortune openFortune(Member receiver) {
+		LocalDate today = LocalDate.now(KST);
+
+		List<Fortune> fortunes = fortuneRepo.findRandomByTodayExcludingSender(receiver, today);
+		if (fortunes.isEmpty()) {
+			throw new AlreadyOpenException();
+		}
+		return fortunes.get(0);
+	}
+
+	@Transactional(readOnly = true)
+	public FortuneResponse getFortune(Long fortuneId) {
+		Fortune fortune = fortuneRepo.findById(fortuneId)
+			.orElseThrow(FortuneNotFoundException::new);
+		return FortuneResponse.from(fortune);
+	}
+
+	@Transactional(readOnly = true)
+	public List<FortuneResponse> getFortunes(Long cursorId, int size) {
+		return fortuneRepo.findByCursor(cursorId, size).stream()
+			.map(FortuneResponse::from)
+			.toList();
+	}
+}

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/service/dto/FortuneResponse.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/fortune/service/dto/FortuneResponse.java
@@ -1,0 +1,15 @@
+package org.goormthon.seasonthon.nocheongmaru.domain.fortune.service.dto;
+
+import org.goormthon.seasonthon.nocheongmaru.domain.fortune.entity.Fortune;
+
+public record FortuneResponse(
+	Long id,
+	String description
+) {
+	public static FortuneResponse from(Fortune fortune) {
+		return new FortuneResponse(
+			fortune.getId(),
+			fortune.getDescription()
+		);
+	}
+}

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/member/entity/Member.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/member/entity/Member.java
@@ -1,5 +1,7 @@
 package org.goormthon.seasonthon.nocheongmaru.domain.member.entity;
 
+import java.time.LocalDate;
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -33,6 +35,8 @@ public class Member extends BaseTimeEntity {
     
     @Column(name = "refresh_token")
     private String refreshToken;
+
+    private LocalDate lastOpenedDate;
     
     @Builder
     private Member(String email, String nickname, String profileImageURL, Role role) {
@@ -45,5 +49,12 @@ public class Member extends BaseTimeEntity {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
-    
+
+    public boolean alreadyOpenedToday() {
+        return LocalDate.now().equals(this.lastOpenedDate);
+    }
+
+    public void markOpenedToday() {
+        this.lastOpenedDate = LocalDate.now();
+    }
 }

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/member/service/MemberService.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/domain/member/service/MemberService.java
@@ -1,0 +1,18 @@
+package org.goormthon.seasonthon.nocheongmaru.domain.member.service;
+
+import org.goormthon.seasonthon.nocheongmaru.domain.member.entity.Member;
+import org.goormthon.seasonthon.nocheongmaru.domain.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public Member getById(Long memberId) {
+		return memberRepository.findById(memberId);
+	}
+}

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/global/exception/common/ErrorCode.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/global/exception/common/ErrorCode.java
@@ -25,7 +25,11 @@ public enum ErrorCode {
     KAKAO_HTTP_CLIENT_ERROR(500, "카카오 API 요청에 실패했습니다."),
     INFORMATION_NOT_FOUND(404, "정보나눔 피드를 찾을 수 없습니다."),
     IS_NOT_INFORMATION_OWNER(403, "정보나눔 피드의 작성자가 아닙니다."),
-    
+
+    // Fortune
+    ALREADY_WRITTEN(500, "오늘은 이미 포춘쿠키를 작성했습니다."),
+    ALREADY_OPEN(500, "오늘 열 수 있는 포춘쿠키가 없습니다."),
+    FORTUNE_NOT_FOUND(404, "포춘쿠키를 찾을 수 없습니다.")
     ;
     
     private final int status;

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/global/exception/member/AlreadyOpenException.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/global/exception/member/AlreadyOpenException.java
@@ -1,0 +1,14 @@
+package org.goormthon.seasonthon.nocheongmaru.global.exception.member;
+
+import org.goormthon.seasonthon.nocheongmaru.global.exception.common.BaseException;
+import org.goormthon.seasonthon.nocheongmaru.global.exception.common.ErrorCode;
+
+public class AlreadyOpenException extends BaseException {
+	public AlreadyOpenException() {
+		super(ErrorCode.ALREADY_OPEN);
+	}
+
+	public AlreadyOpenException(Throwable cause) {
+		super(ErrorCode.ALREADY_OPEN, cause);
+	}
+}

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/global/exception/member/AlreadyWrittenException.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/global/exception/member/AlreadyWrittenException.java
@@ -1,0 +1,14 @@
+package org.goormthon.seasonthon.nocheongmaru.global.exception.member;
+
+import org.goormthon.seasonthon.nocheongmaru.global.exception.common.BaseException;
+import org.goormthon.seasonthon.nocheongmaru.global.exception.common.ErrorCode;
+
+public class AlreadyWrittenException extends BaseException {
+	public AlreadyWrittenException() {
+		super(ErrorCode.ALREADY_WRITTEN);
+	}
+
+	public AlreadyWrittenException(Throwable cause) {
+		super(ErrorCode.ALREADY_WRITTEN, cause);
+	}
+}

--- a/src/main/java/org/goormthon/seasonthon/nocheongmaru/global/exception/member/FortuneNotFoundException.java
+++ b/src/main/java/org/goormthon/seasonthon/nocheongmaru/global/exception/member/FortuneNotFoundException.java
@@ -1,0 +1,14 @@
+package org.goormthon.seasonthon.nocheongmaru.global.exception.member;
+
+import org.goormthon.seasonthon.nocheongmaru.global.exception.common.BaseException;
+import org.goormthon.seasonthon.nocheongmaru.global.exception.common.ErrorCode;
+
+public class FortuneNotFoundException extends BaseException {
+	public FortuneNotFoundException() {
+		super(ErrorCode.FORTUNE_NOT_FOUND);
+	}
+
+	public FortuneNotFoundException(Throwable cause) {
+		super(ErrorCode.FORTUNE_NOT_FOUND, cause);
+	}
+}


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
#19

## 작업 내용 (변경 사항)
- 포춘쿠키 페이지에서 사용자가 포춘쿠키를 작성하여 여러명에게 갈 수 있고, 다른사람으로부터 온 포춘쿠키를 열어볼 수 있다.
- 포춘쿠키 작성과 열어보기는 하루에 한 번 입니다.
- 포춘쿠키 조회 기능 구현
- 포춘쿠키 보내기 기능 구현
- 하루 한 번만 보고 보낼 수 있는 기능으로 구현

## 테스트 결과
`GET` `/api/v1/fortunes/{fortuneId}`
```json
Response
{
  "id": 10,
  "description": "행운은 준비된 사람에게 찾아온다.",
  "senderName": "박영희"
}
```

`GET` `/api/v1/fortunes/cursor`
```json
Response
[
  {
    "id": 14,
    "description": "오늘도 파이팅!",
    "senderName": "이민수"
  },
  {
    "id": 13,
    "description": "좋은 소식이 찾아올 거예요.",
    "senderName": "최은지"
  }
]
```

`POST` `/api/v1/fortunes/send`
```json
Request
{
  "description": "오늘도 좋은 하루 보내세요!"
}
Response
{
  "id": 1,
  "description": "오늘도 좋은 하루 보내세요!",
  "senderName": "홍길동"
}
```

`POST` `/api/v1/fortunes/open`
```json
Response
{
  "id": 5,
  "description": "너의 오늘 하루는 행운으로 가득할거야 🍀",
  "senderName": "김철수"
}
```